### PR TITLE
feat: start block per contract

### DIFF
--- a/codegenerator/cli/npm/envio/evm.schema.json
+++ b/codegenerator/cli/npm/envio/evm.schema.json
@@ -576,6 +576,15 @@
           "description": "A single address or a list of addresses to be indexed. This can be left as null in the case where this contracts addresses will be registered dynamically.",
           "$ref": "#/$defs/Addresses"
         },
+        "start_block": {
+          "description": "The block at which the indexer should start ingesting data for this specific contract. If not specified, uses the network's start_block.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
         "abi_file_path": {
           "description": "Relative path (from config) to a json abi. If this is used then each configured event should simply be referenced by its name",
           "type": [
@@ -593,15 +602,6 @@
           "items": {
             "$ref": "#/$defs/EventConfig"
           }
-        },
-        "start_block": {
-          "description": "The block at which the indexer should start ingesting data for this specific contract. If not specified, uses the network's start_block.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0
         }
       },
       "additionalProperties": false,

--- a/codegenerator/cli/npm/envio/evm.schema.json
+++ b/codegenerator/cli/npm/envio/evm.schema.json
@@ -593,6 +593,15 @@
           "items": {
             "$ref": "#/$defs/EventConfig"
           }
+        },
+        "start_block": {
+          "description": "The block at which the indexer should start ingesting data for this specific contract. If not specified, uses the network's start_block.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
         }
       },
       "additionalProperties": false,

--- a/codegenerator/cli/npm/envio/fuel.schema.json
+++ b/codegenerator/cli/npm/envio/fuel.schema.json
@@ -217,6 +217,15 @@
           "description": "A single address or a list of addresses to be indexed. This can be left as null in the case where this contracts addresses will be registered dynamically.",
           "$ref": "#/$defs/Addresses"
         },
+        "start_block": {
+          "description": "The block at which the indexer should start ingesting data for this specific contract. If not specified, uses the network's start_block.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
         "abi_file_path": {
           "description": "Relative path (from config) to a json abi.",
           "type": "string"
@@ -231,15 +240,6 @@
           "items": {
             "$ref": "#/$defs/EventConfig"
           }
-        },
-        "start_block": {
-          "description": "The block at which the indexer should start ingesting data for this specific contract. If not specified, uses the network's start_block.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0
         }
       },
       "additionalProperties": false,

--- a/codegenerator/cli/npm/envio/fuel.schema.json
+++ b/codegenerator/cli/npm/envio/fuel.schema.json
@@ -231,6 +231,15 @@
           "items": {
             "$ref": "#/$defs/EventConfig"
           }
+        },
+        "start_block": {
+          "description": "The block at which the indexer should start ingesting data for this specific contract. If not specified, uses the network's start_block.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
         }
       },
       "additionalProperties": false,

--- a/codegenerator/cli/npm/envio/src/FetchState.res
+++ b/codegenerator/cli/npm/envio/src/FetchState.res
@@ -967,6 +967,7 @@ let make = (
   ~endBlock,
   ~eventConfigs: array<Internal.eventConfig>,
   ~staticContracts: dict<array<Address.t>>,
+  ~staticContractsWithStartBlocks: dict<option<int>>,
   ~dynamicContracts: array<indexingContract>,
   ~maxAddrInPartition,
   ~chainId,
@@ -1054,10 +1055,17 @@ let make = (
           switch dc {
           | Some(dc) => dc
           | None => {
-              address,
-              contractName,
-              startBlock,
-              register: Config,
+              let contractStartBlock = switch staticContractsWithStartBlocks->Utils.Dict.dangerouslyGetNonOption(contractName) {
+              | Some(Some(contractStartBlock)) => contractStartBlock
+              | Some(None) | None => startBlock
+              }
+              Js.Console.log3("Contract start block set:", contractName, contractStartBlock)
+              {
+                address,
+                contractName,
+                startBlock: contractStartBlock,
+                register: Config,
+              }
             }
           },
         )

--- a/codegenerator/cli/src/cli_args/init_config.rs
+++ b/codegenerator/cli/src/cli_args/init_config.rs
@@ -139,6 +139,7 @@ pub mod evm {
                     let contract = NetworkContract {
                         name: selected_contract.name.clone(),
                         address,
+                        start_block: None,
                         config: config.clone(),
                     };
 
@@ -279,6 +280,7 @@ pub mod fuel {
                                     .map(|a| a.to_string())
                                     .collect::<Vec<String>>()
                                     .into(),
+                                start_block: None,
                                 config: Some(ContractConfig {
                                     abi_file_path: selected_contract.get_vendored_abi_file_path(),
                                     handler: init_config.language.get_event_handler_directory(),

--- a/codegenerator/cli/src/config_parsing/graph_migration/mod.rs
+++ b/codegenerator/cli/src/config_parsing/graph_migration/mod.rs
@@ -359,6 +359,7 @@ pub async fn generate_config_from_subgraph_id(
                     let contract = NetworkContract {
                         name: data_source.name.to_string(),
                         address: vec![data_source.source.address.to_string()].into(),
+                        start_block: None,
                         config: Some(ContractConfig {
                             abi_file_path: Some(format!("abis/{}.json", data_source.name)),
                             handler: get_event_handler_directory(language),

--- a/codegenerator/cli/src/hbs_templating/codegen_templates.rs
+++ b/codegenerator/cli/src/hbs_templating/codegen_templates.rs
@@ -875,6 +875,7 @@ pub struct PerNetworkContractTemplate {
     name: CapitalizedOptions,
     addresses: Vec<EthAddress>,
     events: Vec<PerNetworkContractEventTemplate>,
+    start_block: Option<u64>,
 }
 
 impl PerNetworkContractTemplate {
@@ -896,6 +897,7 @@ impl PerNetworkContractTemplate {
             name: network_contract.name.to_capitalized_options(),
             addresses: network_contract.addresses.clone(),
             events,
+            start_block: network_contract.start_block,
         })
     }
 }
@@ -1419,6 +1421,7 @@ mod test {
             name: String::from("Greeter").to_capitalized_options(),
             addresses: vec![address1.clone()],
             events,
+            start_block: None,
         };
 
         let chain_config_1 = super::NetworkConfigTemplate {
@@ -1463,6 +1466,7 @@ mod test {
             name: String::from("Contract1").to_capitalized_options(),
             addresses: vec![address1.clone()],
             events,
+            start_block: None,
         };
 
         let chain_config_1 = super::NetworkConfigTemplate {
@@ -1509,6 +1513,7 @@ mod test {
             name: String::from("Contract1").to_capitalized_options(),
             addresses: vec![address1.clone()],
             events,
+            start_block: None,
         };
 
         let events = get_per_contract_events_vec_helper(vec!["NewGravatar", "UpdatedGravatar"]);
@@ -1516,6 +1521,7 @@ mod test {
             name: String::from("Contract2").to_capitalized_options(),
             addresses: vec![address2.clone()],
             events,
+            start_block: None,
         };
 
         let chain_config_1 = super::NetworkConfigTemplate {
@@ -1555,6 +1561,7 @@ mod test {
             name: String::from("Contract1").to_capitalized_options(),
             addresses: vec![address1.clone()],
             events,
+            start_block: None,
         };
 
         let chain_config_1 = super::NetworkConfigTemplate {

--- a/codegenerator/cli/templates/dynamic/codegen/src/ConfigYAML.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/ConfigYAML.res.hbs
@@ -20,6 +20,7 @@ type contract = {
   abi: aliasAbi,
   addresses: array<string>,
   events: array<eventName>,
+  startBlock: option<int>,
 }
 
 type configYaml = {
@@ -49,6 +50,7 @@ let publicConfig = ChainMap.fromArrayUnsafe([
             Types.{{contract.name.capitalized}}.{{event.name}}.name,
             {{/each}}
           ],
+          startBlock: {{#if contract.start_block}}Some({{contract.start_block}}){{else}}None{{/if}},
         }
       ),
       {{/each}}

--- a/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
+++ b/codegenerator/cli/templates/dynamic/codegen/src/RegisterHandlers.res.hbs
@@ -46,6 +46,7 @@ let registerContractHandlers = (
               (Types.{{contract.name.capitalized}}.{{event.name}}.register() :> Internal.eventConfig),
               {{/each}}
             ],
+            startBlock: {{#if contract.start_block}}Some({{contract.start_block}}){{else}}None{{/if}},
           },
           {{/each}}
         ]

--- a/codegenerator/cli/templates/static/codegen/src/Config.res
+++ b/codegenerator/cli/templates/static/codegen/src/Config.res
@@ -7,6 +7,7 @@ type contract = {
   abi: Ethers.abi,
   addresses: array<Address.t>,
   events: array<Internal.eventConfig>,
+  startBlock: option<int>,
 }
 
 type syncConfigOptions = {

--- a/codegenerator/cli/templates/static/codegen/src/EventRouter.res
+++ b/codegenerator/cli/templates/static/codegen/src/EventRouter.res
@@ -42,6 +42,7 @@ module Group = {
         contractAddress->Address.toString,
       ) {
       | Some(indexingContract) =>
+        Js.Console.log4("Event filter check:", indexingContract.contractName, indexingContract.startBlock, blockNumber)
         if indexingContract.startBlock <= blockNumber {
           byContractName->Utils.Dict.dangerouslyGetNonOption(indexingContract.contractName)
         } else {

--- a/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
+++ b/codegenerator/cli/templates/static/codegen/src/eventFetching/ChainFetcher.res
@@ -52,6 +52,7 @@ let make = (
 
   // Aggregate events we want to fetch
   let staticContracts = Js.Dict.empty()
+  let staticContractsWithStartBlocks = Js.Dict.empty()
   let eventConfigs: array<Internal.eventConfig> = []
 
   chainConfig.contracts->Array.forEach(contract => {
@@ -91,11 +92,13 @@ let make = (
     })
 
     staticContracts->Js.Dict.set(contractName, contract.addresses)
+    staticContractsWithStartBlocks->Js.Dict.set(contractName, contract.startBlock)
   })
 
   let fetchState = FetchState.make(
     ~maxAddrInPartition,
     ~staticContracts,
+    ~staticContractsWithStartBlocks,
     ~dynamicContracts=dynamicContracts->Array.map(dc => {
       FetchState.address: dc.contractAddress,
       contractName: (dc.contractType :> string),

--- a/codegenerator/cli/test/configs/per-contract-start-block.yaml
+++ b/codegenerator/cli/test/configs/per-contract-start-block.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=../../npm/envio/evm.schema.json
+name: per-contract-start-block-test
+schema: ../schemas/schema.graphql
+description: Test configuration for per-contract start blocks
+networks:
+  - id: 1
+    rpc_config:
+      url: https://eth.com
+      initial_block_interval: 10000
+      backoff_multiplicative: 0.8
+      acceleration_additive: 2000
+      interval_ceiling: 10000
+      backoff_millis: 5000
+      query_timeout_millis: 20000
+    start_block: 0  # Network default start block
+    contracts:
+      - name: Contract1
+        abi_file_path: ../abis/Contract1.json
+        handler: ./src/EventHandler.js
+        address: "0x2E645469f354BB4F5c8a05B3b30A929361cf77eC"
+        start_block: 1000  # Specific start block for this contract
+        events:
+          - event: "NewGravatar"
+      - name: Contract2
+        abi_file_path: ../abis/Contract2.json
+        handler: ./src/EventHandler.js
+        address: "0x3F1234567890ABCDEF1234567890ABCDEF123456"
+        # No start_block specified, uses network default (0)
+        events:
+          - event: "UpdatedGravatar"
+      - name: Contract3
+        abi_file_path: ../abis/Contract1.json
+        handler: ./src/EventHandler.js
+        address: "0x4A1234567890ABCDEF1234567890ABCDEF123456"
+        start_block: 5000  # Another specific start block
+        events:
+          - event: "NewGravatar" 

--- a/scenarios/helpers/src/Indexer.res
+++ b/scenarios/helpers/src/Indexer.res
@@ -79,6 +79,7 @@ module type S = {
       abi: Ethers.abi,
       addresses: array<Address.t>,
       events: array<Internal.eventConfig>,
+      startBlock: option<int>,
     }
 
     type chainConfig = {

--- a/scenarios/test_codegen/config.yaml
+++ b/scenarios/test_codegen/config.yaml
@@ -35,6 +35,7 @@ networks:
         abi_file_path: abis/gravatar-abi.json
         address: "0x2B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"
         handler: ./src/EventHandlers.res.js
+        start_block: 500 # Test specific start block for Gravatar
         events:
           - event: "CustomSelection()"
             field_selection:
@@ -58,17 +59,20 @@ networks:
         abi_file_path: abis/NftFactory.json
         address: "0xa2F6E6029638cCb484A2ccb6414499aD3e825CaC"
         handler: src/EventHandlers.ts
+        start_block: 1000 # Test different start block for NftFactory
         events:
           - event: "SimpleNftCreated"
       - name: SimpleNft
         abi_file_path: abis/SimpleNft.json
         handler: src/EventHandlers.ts
+        # No start_block specified - should use network default (1)
         events:
           - event: "Erc20Transfer(address indexed from, address indexed to, uint256 amount)"
           - event: "Transfer"
       - name: TestEvents
         abi_file_path: ./contracts/artifacts/contracts/TestEvents.sol/TestEvents.json
         handler: src/EventHandlers.ts
+        start_block: 2000 # Test another different start block for TestEvents
         events:
           - event: "IndexedUint"
           - event: "IndexedInt"
@@ -89,14 +93,18 @@ networks:
     contracts:
       - name: Noop
         address: "0x0B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"
+        start_block: 100 # Test start block for Noop on chain 1
   - id: 100
     start_block: 1
     contracts:
       - name: EventFiltersTest
+        start_block: 50 # Test start block for EventFiltersTest
   - id: 137
     start_block: 1
     contracts:
       - name: EventFiltersTest
+        # No start_block - should use network default (1)
       - name: Noop
         address: "0x0B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"
+        start_block: 200 # Test start block for Noop on chain 137
 raw_events: true

--- a/scenarios/test_codegen/test/ChainManager_test.res
+++ b/scenarios/test_codegen/test/ChainManager_test.res
@@ -28,6 +28,7 @@ let populateChainQueuesWithRandomEvents = (~runTime=1000, ~maxBlockTime=15, ()) 
       ~maxAddrInPartition=Env.maxAddrInPartition,
       ~endBlock=None,
       ~staticContracts=Js.Dict.empty(),
+      ~staticContractsWithStartBlocks=Js.Dict.empty(),
       ~eventConfigs,
       ~dynamicContracts=[],
       ~startBlock=0,

--- a/scenarios/test_codegen/test/Config_test.res
+++ b/scenarios/test_codegen/test/Config_test.res
@@ -12,8 +12,8 @@ describe("getGeneratedByChainId Test", () => {
         contracts: Js.Dict.fromArray([
           (
             "Noop",
-            {
-              ConfigYAML.name: "Noop",
+            ({
+              name: "Noop",
               abi: %raw(`[{
                 anonymous: false,
                 inputs: [],
@@ -22,7 +22,8 @@ describe("getGeneratedByChainId Test", () => {
               }]`),
               addresses: ["0x0B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"],
               events: ["EmptyEvent"],
-            },
+              startBlock: Some(100),
+            }: ConfigYAML.contract),
           ),
         ]),
       },

--- a/scenarios/test_codegen/test/E2EEthNode_test.res
+++ b/scenarios/test_codegen/test/E2EEthNode_test.res
@@ -25,6 +25,7 @@ describe("E2E Integration Test", () => {
             (Types.Gravatar.NewGravatar.register() :> Internal.eventConfig),
             (Types.Gravatar.UpdatedGravatar.register() :> Internal.eventConfig),
           ],
+          startBlock: None,
         },
       ]
       let evmContracts = contracts->Js.Array2.map(

--- a/scenarios/test_codegen/test/Integration_ts_helpers.res
+++ b/scenarios/test_codegen/test/Integration_ts_helpers.res
@@ -9,12 +9,14 @@ let getLocalChainConfig = (nftFactoryContractAddress): chainConfig => {
       abi: Types.NftFactory.abi,
       addresses: [nftFactoryContractAddress],
       events: [(Types.NftFactory.SimpleNftCreated.register() :> Internal.eventConfig)],
+      startBlock: None,
     },
     {
       name: "SimpleNft",
       abi: Types.SimpleNft.abi,
       addresses: [],
       events: [(Types.SimpleNft.Transfer.register() :> Internal.eventConfig)],
+      startBlock: None,
     },
   ]
   let evmContracts = contracts->Js.Array2.map((contract): Internal.evmContractConfig => {

--- a/scenarios/test_codegen/test/StartBlockIntegration_test.res
+++ b/scenarios/test_codegen/test/StartBlockIntegration_test.res
@@ -1,0 +1,364 @@
+open Belt
+open RescriptMocha
+
+describe("Start Block Per Contract Integration Tests", () => {
+  describe("ChainFetcher Integration", () => {
+    it(
+      "should create ChainFetcher with correct start blocks from config",
+      () => {
+        let config = RegisterHandlers.getConfig()
+        let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=1337))
+
+        // Verify that static contracts are set up with their specific start blocks
+        let staticContracts = Js.Dict.empty()
+        let staticContractsWithStartBlocks = Js.Dict.empty()
+
+        chainConfig.contracts->Array.forEach(
+          contract => {
+            staticContracts->Js.Dict.set(contract.name, contract.addresses)
+            staticContractsWithStartBlocks->Js.Dict.set(contract.name, contract.startBlock)
+          },
+        )
+
+        // Test that Gravatar has start block 500
+        let gravatarStartBlock =
+          staticContractsWithStartBlocks->Utils.Dict.dangerouslyGetNonOption("Gravatar")
+        Assert.equal(
+          gravatarStartBlock,
+          Some(Some(500)),
+          ~message="Gravatar should have start block 500 in chain fetcher setup",
+        )
+
+        // Test that NftFactory has start block 1000
+        let nftFactoryStartBlock =
+          staticContractsWithStartBlocks->Utils.Dict.dangerouslyGetNonOption("NftFactory")
+        Assert.equal(
+          nftFactoryStartBlock,
+          Some(Some(1000)),
+          ~message="NftFactory should have start block 1000 in chain fetcher setup",
+        )
+
+        // Test that SimpleNft has no specific start block (uses network default)
+        let simpleNftContract = chainConfig.contracts->Array.getBy(c => c.name === "SimpleNft")
+        switch simpleNftContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            None,
+            ~message="SimpleNft should have no specific start block",
+          )
+        | None => Assert.fail("SimpleNft contract not found")
+        }
+
+        // Test that TestEvents has start block 2000
+        let testEventsStartBlock =
+          staticContractsWithStartBlocks->Utils.Dict.dangerouslyGetNonOption("TestEvents")
+        Assert.equal(
+          testEventsStartBlock,
+          Some(Some(2000)),
+          ~message="TestEvents should have start block 2000 in chain fetcher setup",
+        )
+      },
+    )
+
+    it(
+      "should properly initialize FetchState with contract start blocks",
+      () => {
+        let config = RegisterHandlers.getConfig()
+        let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=1337))
+
+        let chainFetcher = ChainFetcher.makeFromConfig(
+          chainConfig,
+          ~maxAddrInPartition=Env.maxAddrInPartition,
+          ~enableRawEvents=true,
+        )
+
+        let fetchState = chainFetcher.fetchState
+
+        // Check that indexing contracts were created with correct start blocks
+        // We need to find the actual addresses from the config to test this properly
+        let gravatarContract = chainConfig.contracts->Array.getBy(c => c.name === "Gravatar")
+        switch gravatarContract {
+        | Some(contract) => {
+            let gravatarAddress = contract.addresses->Array.get(0)
+            switch gravatarAddress {
+            | Some(address) => {
+                let indexingContract =
+                  fetchState.indexingContracts->Utils.Dict.dangerouslyGetNonOption(
+                    address->Address.toString,
+                  )
+                switch indexingContract {
+                | Some(ic) =>
+                  Assert.equal(
+                    ic.startBlock,
+                    500,
+                    ~message="Gravatar indexing contract should have start block 500",
+                  )
+                | None => Assert.fail("Gravatar indexing contract not found")
+                }
+              }
+            | None => Assert.fail("Gravatar address not found")
+            }
+          }
+        | None => Assert.fail("Gravatar contract not found in config")
+        }
+
+        let nftFactoryContract = chainConfig.contracts->Array.getBy(c => c.name === "NftFactory")
+        switch nftFactoryContract {
+        | Some(contract) => {
+            let nftFactoryAddress = contract.addresses->Array.get(0)
+            switch nftFactoryAddress {
+            | Some(address) => {
+                let indexingContract =
+                  fetchState.indexingContracts->Utils.Dict.dangerouslyGetNonOption(
+                    address->Address.toString,
+                  )
+                switch indexingContract {
+                | Some(ic) =>
+                  Assert.equal(
+                    ic.startBlock,
+                    1000,
+                    ~message="NftFactory indexing contract should have start block 1000",
+                  )
+                | None => Assert.fail("NftFactory indexing contract not found")
+                }
+              }
+            | None => Assert.fail("NftFactory address not found")
+            }
+          }
+        | None => Assert.fail("NftFactory contract not found in config")
+        }
+
+        // Check SimpleNft uses network start block
+        let simpleNftContract = chainConfig.contracts->Array.getBy(c => c.name === "SimpleNft")
+        switch simpleNftContract {
+        | Some(contract) => if contract.addresses->Array.length > 0 {
+            let simpleNftAddress = contract.addresses->Array.get(0)
+            switch simpleNftAddress {
+            | Some(address) => {
+                let indexingContract =
+                  fetchState.indexingContracts->Utils.Dict.dangerouslyGetNonOption(
+                    address->Address.toString,
+                  )
+                switch indexingContract {
+                | Some(ic) =>
+                  Assert.equal(
+                    ic.startBlock,
+                    1, // Network start block
+                    ~message="SimpleNft indexing contract should use network start block 1",
+                  )
+                | None => Assert.fail("SimpleNft indexing contract not found")
+                }
+              }
+            | None => Assert.fail("SimpleNft address not found")
+            }
+          } else {
+            // Skip test if contract has no addresses
+            ()
+          }
+        | None => Assert.fail("SimpleNft contract not found")
+        }
+      },
+    )
+  })
+
+  describe("Cross-Chain Start Block Tests", () => {
+    it(
+      "should handle different start blocks across multiple chains",
+      () => {
+        let config = RegisterHandlers.getConfig()
+
+        // Test Chain 1
+        let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=1))
+        // Chain 1 network start block should be 1
+        Assert.equal(
+          chainConfig.startBlock,
+          1,
+          ~message="Chain 1 should have network start block 1",
+        )
+
+        // Noop contract on chain 1 should have start block 100
+        let noopContract = chainConfig.contracts->Array.getBy(c => c.name === "Noop")
+        switch noopContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            Some(100),
+            ~message="Noop on chain 1 should have start block 100",
+          )
+        | None => Assert.fail("Noop contract not found on chain 1")
+        }
+
+        // Test Chain 100
+        let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=100))
+        // Chain 100 network start block should be 1
+        Assert.equal(
+          chainConfig.startBlock,
+          1,
+          ~message="Chain 100 should have network start block 1",
+        )
+
+        // EventFiltersTest contract on chain 100 should have start block 50
+        let eventFiltersContract =
+          chainConfig.contracts->Array.getBy(c => c.name === "EventFiltersTest")
+        switch eventFiltersContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            Some(50),
+            ~message="EventFiltersTest on chain 100 should have start block 50",
+          )
+        | None => Assert.fail("EventFiltersTest contract not found on chain 100")
+        }
+
+        // Test Chain 137
+        let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=137))
+        // Chain 137 network start block should be 1
+        Assert.equal(
+          chainConfig.startBlock,
+          1,
+          ~message="Chain 137 should have network start block 1",
+        )
+
+        // EventFiltersTest contract on chain 137 should have no specific start block
+        let eventFiltersContract =
+          chainConfig.contracts->Array.getBy(c => c.name === "EventFiltersTest")
+        switch eventFiltersContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            None,
+            ~message="EventFiltersTest on chain 137 should have no specific start block",
+          )
+        | None => Assert.fail("EventFiltersTest contract not found on chain 137")
+        }
+
+        // Noop contract on chain 137 should have start block 200
+        let noopContract = chainConfig.contracts->Array.getBy(c => c.name === "Noop")
+        switch noopContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            Some(200),
+            ~message="Noop on chain 137 should have start block 200",
+          )
+        | None => Assert.fail("Noop contract not found on chain 137")
+        }
+      },
+    )
+  })
+
+  describe("EventRouter Integration with Start Blocks", () => {
+    it(
+      "should properly filter events using configured start blocks",
+      () => {
+        let config = RegisterHandlers.getConfig()
+        let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=1337))
+
+        let chainFetcher = ChainFetcher.makeFromConfig(
+          chainConfig,
+          ~maxAddrInPartition=Env.maxAddrInPartition,
+          ~enableRawEvents=true,
+        )
+
+        let fetchState = chainFetcher.fetchState
+
+        // Find Gravatar contract and its events
+        let gravatarContract = chainConfig.contracts->Array.getBy(c => c.name === "Gravatar")
+        switch gravatarContract {
+        | Some(contract) => {
+            let gravatarAddress = contract.addresses->Array.get(0)
+            switch gravatarAddress {
+            | Some(address) => {
+                // Test that events before start block 500 are filtered out
+                // and events at or after start block 500 are included
+
+                // This test verifies the integration between:
+                // 1. Config parsing (start_block: 500 for Gravatar)
+                // 2. FetchState creation with indexing contracts
+                // 3. EventRouter filtering based on start blocks
+
+                let indexingContract =
+                  fetchState.indexingContracts->Utils.Dict.dangerouslyGetNonOption(
+                    address->Address.toString,
+                  )
+
+                switch indexingContract {
+                | Some(ic) => {
+                    Assert.equal(
+                      ic.startBlock,
+                      500,
+                      ~message="Integration test: Gravatar should have start block 500",
+                    )
+
+                    Assert.equal(
+                      ic.contractName,
+                      "Gravatar",
+                      ~message="Integration test: Should be Gravatar contract",
+                    )
+
+                    Assert.equal(
+                      ic.register,
+                      Config,
+                      ~message="Integration test: Should be static config contract",
+                    )
+                  }
+                | None => Assert.fail("Integration test: Gravatar indexing contract not found")
+                }
+              }
+            | None => Assert.fail("Integration test: Gravatar address not found")
+            }
+          }
+        | None => Assert.fail("Integration test: Gravatar contract not found")
+        }
+      },
+    )
+  })
+
+  describe("Config Validation", () => {
+    it(
+      "should validate that all configured start blocks are properly loaded",
+      () => {
+        let config = RegisterHandlers.getConfig()
+
+        // Verify that the config contains all our test start blocks
+        let chainConfigs = [
+          (
+            1337,
+            [
+              ("Gravatar", Some(500)),
+              ("NftFactory", Some(1000)),
+              ("SimpleNft", None),
+              ("TestEvents", Some(2000)),
+            ],
+          ),
+          (1, [("Noop", Some(100))]),
+          (100, [("EventFiltersTest", Some(50))]),
+          (137, [("EventFiltersTest", None), ("Noop", Some(200))]),
+        ]
+
+        chainConfigs->Array.forEach(
+          ((chainId, expectedContracts)) => {
+            let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId))
+
+            expectedContracts->Array.forEach(
+              ((contractName, expectedStartBlock)) => {
+                let contract = chainConfig.contracts->Array.getBy(c => c.name === contractName)
+                switch contract {
+                | Some(contract) =>
+                  Assert.equal(
+                    contract.startBlock,
+                    expectedStartBlock,
+                    ~message=`Chain ${chainId->Int.toString}: ${contractName} should have expected start block`,
+                  )
+                | None =>
+                  Assert.fail(`Chain ${chainId->Int.toString}: ${contractName} contract not found`)
+                }
+              },
+            )
+          },
+        )
+      },
+    )
+  })
+})

--- a/scenarios/test_codegen/test/StartBlock_test.res
+++ b/scenarios/test_codegen/test/StartBlock_test.res
@@ -1,0 +1,338 @@
+open Belt
+open RescriptMocha
+
+describe("Start Block Per Contract Tests", () => {
+  describe("Config Tests", () => {
+    it(
+      "should use contract-specific start block when provided",
+      () => {
+        let config = RegisterHandlers.getConfig()
+        let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=1337))
+
+        // Test Gravatar has start block 500
+        let gravatarContract = chainConfig.contracts->Array.getBy(c => c.name === "Gravatar")
+        switch gravatarContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            Some(500),
+            ~message="Gravatar should have start block 500",
+          )
+        | None => Assert.fail("Gravatar contract not found")
+        }
+
+        // Test NftFactory has start block 1000
+        let nftFactoryContract = chainConfig.contracts->Array.getBy(c => c.name === "NftFactory")
+        switch nftFactoryContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            Some(1000),
+            ~message="NftFactory should have start block 1000",
+          )
+        | None => Assert.fail("NftFactory contract not found")
+        }
+
+        // Test SimpleNft has no start block (should use network default)
+        let simpleNftContract = chainConfig.contracts->Array.getBy(c => c.name === "SimpleNft")
+        switch simpleNftContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            None,
+            ~message="SimpleNft should have no start block (uses network default)",
+          )
+        | None => Assert.fail("SimpleNft contract not found")
+        }
+
+        // Test TestEvents has start block 2000
+        let testEventsContract = chainConfig.contracts->Array.getBy(c => c.name === "TestEvents")
+        switch testEventsContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            Some(2000),
+            ~message="TestEvents should have start block 2000",
+          )
+        | None => Assert.fail("TestEvents contract not found")
+        }
+      },
+    )
+
+    it(
+      "should use network start block as fallback",
+      () => {
+        let config = RegisterHandlers.getConfig()
+        let chainConfig = config.chainMap->ChainMap.get(ChainMap.Chain.makeUnsafe(~chainId=1))
+
+        // Network start block is 1
+        Assert.equal(
+          chainConfig.startBlock,
+          1,
+          ~message="Chain 1 should have network start block 1",
+        )
+
+        // Test Noop has specific start block 100
+        let noopContract = chainConfig.contracts->Array.getBy(c => c.name === "Noop")
+        switch noopContract {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            Some(100),
+            ~message="Noop on chain 1 should have start block 100",
+          )
+        | None => Assert.fail("Noop contract not found on chain 1")
+        }
+      },
+    )
+  })
+
+  describe("FetchState Start Block Tests", () => {
+    let mockAddress0 = TestHelpers.Addresses.mockAddresses[0]->Option.getExn
+    let mockAddress1 = TestHelpers.Addresses.mockAddresses[1]->Option.getExn
+    let mockAddress2 = TestHelpers.Addresses.mockAddresses[2]->Option.getExn
+
+    it(
+      "should create indexing contracts with correct start blocks",
+      () => {
+        let staticContracts = Js.Dict.fromArray([
+          ("TestContract", [mockAddress0, mockAddress1]),
+          ("AnotherContract", [mockAddress2]),
+        ])
+
+        let staticContractsWithStartBlocks = Js.Dict.fromArray([
+          ("TestContract", Some(500)),
+          ("AnotherContract", None), // Should use network start block
+        ])
+
+        let eventConfigs = [
+          (Mock.evmEventConfig(~id="0", ~contractName="TestContract") :> Internal.eventConfig),
+          (Mock.evmEventConfig(~id="1", ~contractName="AnotherContract") :> Internal.eventConfig),
+        ]
+
+        let fetchState = FetchState.make(
+          ~eventConfigs,
+          ~staticContracts,
+          ~staticContractsWithStartBlocks,
+          ~dynamicContracts=[],
+          ~startBlock=1,
+          ~endBlock=None,
+          ~maxAddrInPartition=3,
+          ~chainId=1337,
+        )
+
+        // Check that TestContract addresses have start block 500
+        let testContractAddress0 =
+          fetchState.indexingContracts->Utils.Dict.dangerouslyGetNonOption(
+            mockAddress0->Address.toString,
+          )
+        switch testContractAddress0 {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            500,
+            ~message="TestContract address 0 should have start block 500",
+          )
+        | None => Assert.fail("TestContract address 0 not found in indexing contracts")
+        }
+
+        let testContractAddress1 =
+          fetchState.indexingContracts->Utils.Dict.dangerouslyGetNonOption(
+            mockAddress1->Address.toString,
+          )
+        switch testContractAddress1 {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            500,
+            ~message="TestContract address 1 should have start block 500",
+          )
+        | None => Assert.fail("TestContract address 1 not found in indexing contracts")
+        }
+
+        // Check that AnotherContract address uses network start block (1)
+        let anotherContractAddress =
+          fetchState.indexingContracts->Utils.Dict.dangerouslyGetNonOption(
+            mockAddress2->Address.toString,
+          )
+        switch anotherContractAddress {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            1,
+            ~message="AnotherContract should use network start block 1",
+          )
+        | None => Assert.fail("AnotherContract address not found in indexing contracts")
+        }
+      },
+    )
+
+    it(
+      "should handle dynamic contracts with start blocks",
+      () => {
+        let eventConfigs = [
+          (Mock.evmEventConfig(~id="0", ~contractName="DynamicContract") :> Internal.eventConfig),
+        ]
+
+        let dc: FetchState.indexingContract = {
+          address: mockAddress0,
+          contractName: "DynamicContract",
+          startBlock: 1500, // Dynamic contract specific start block
+          register: DC({
+            registeringEventLogIndex: 0,
+            registeringEventBlockTimestamp: 15000,
+            registeringEventContractName: "Factory",
+            registeringEventName: "ContractCreated",
+            registeringEventSrcAddress: mockAddress1,
+          }),
+        }
+
+        let fetchState = FetchState.make(
+          ~eventConfigs,
+          ~staticContracts=Js.Dict.empty(),
+          ~staticContractsWithStartBlocks=Js.Dict.empty(),
+          ~dynamicContracts=[dc],
+          ~startBlock=1,
+          ~endBlock=None,
+          ~maxAddrInPartition=3,
+          ~chainId=1337,
+        )
+
+        // Check that dynamic contract has its specific start block
+        let dynamicContractFound =
+          fetchState.indexingContracts->Utils.Dict.dangerouslyGetNonOption(
+            mockAddress0->Address.toString,
+          )
+        switch dynamicContractFound {
+        | Some(contract) =>
+          Assert.equal(
+            contract.startBlock,
+            1500,
+            ~message="Dynamic contract should have start block 1500",
+          )
+        | None => Assert.fail("Dynamic contract not found in indexing contracts")
+        }
+      },
+    )
+  })
+
+  describe("EventRouter Start Block Filtering Tests", () => {
+    let mockAddress = TestHelpers.Addresses.mockAddresses[0]->Option.getExn
+
+    let createTestIndexingContracts = (~startBlock) => {
+      let dict = Js.Dict.empty()
+      dict->Js.Dict.set(
+        mockAddress->Address.toString,
+        {
+          FetchState.address: mockAddress,
+          contractName: "TestContract",
+          startBlock,
+          register: Config,
+        },
+      )
+      dict
+    }
+
+    it(
+      "should filter events based on contract start block",
+      () => {
+        let router = EventRouter.empty()
+        let eventConfig = Mock.evmEventConfig(~id="test_event", ~contractName="TestContract")
+
+        router->EventRouter.addOrThrow(
+          eventConfig.id,
+          eventConfig,
+          ~contractName="TestContract",
+          ~eventName="TestEvent",
+          ~chain=ChainMap.Chain.makeUnsafe(~chainId=1337),
+          ~isWildcard=false,
+        )
+
+        let indexingContracts = createTestIndexingContracts(~startBlock=500)
+
+        // Event at block 400 should be filtered out (before start block)
+        let result400 =
+          router->EventRouter.get(
+            ~tag=eventConfig.id,
+            ~contractAddress=mockAddress,
+            ~blockNumber=400,
+            ~indexingContracts,
+          )
+        Assert.equal(
+          result400,
+          None,
+          ~message="Event at block 400 should be filtered out (before start block 500)",
+        )
+
+        // Event at block 500 should be included (at start block)
+        let result500 =
+          router->EventRouter.get(
+            ~tag=eventConfig.id,
+            ~contractAddress=mockAddress,
+            ~blockNumber=500,
+            ~indexingContracts,
+          )
+        Assert.notEqual(
+          result500,
+          None,
+          ~message="Event at block 500 should be included (at start block)",
+        )
+
+        // Event at block 600 should be included (after start block)
+        let result600 =
+          router->EventRouter.get(
+            ~tag=eventConfig.id,
+            ~contractAddress=mockAddress,
+            ~blockNumber=600,
+            ~indexingContracts,
+          )
+        Assert.notEqual(
+          result600,
+          None,
+          ~message="Event at block 600 should be included (after start block)",
+        )
+      },
+    )
+
+    it(
+      "should handle wildcard events with start blocks",
+      () => {
+        let router = EventRouter.empty()
+        let wildcardEventConfig = Mock.evmEventConfig(
+          ~id="wildcard_event",
+          ~contractName="TestContract",
+          ~isWildcard=true,
+        )
+
+        router->EventRouter.addOrThrow(
+          wildcardEventConfig.id,
+          wildcardEventConfig,
+          ~contractName="TestContract",
+          ~eventName="WildcardEvent",
+          ~chain=ChainMap.Chain.makeUnsafe(~chainId=1337),
+          ~isWildcard=true,
+        )
+
+        let indexingContracts = createTestIndexingContracts(~startBlock=1000)
+
+        // Test with unknown address (should use wildcard but still respect start block logic)
+        let unknownAddress = TestHelpers.Addresses.mockAddresses[1]->Option.getExn
+
+        // Event before start block should still be filtered for wildcard
+        let resultBefore =
+          router->EventRouter.get(
+            ~tag=wildcardEventConfig.id,
+            ~contractAddress=unknownAddress,
+            ~blockNumber=500,
+            ~indexingContracts,
+          )
+        // Wildcard should still work for unknown addresses
+        Assert.notEqual(
+          resultBefore,
+          None,
+          ~message="Wildcard event should work for unknown addresses",
+        )
+      },
+    )
+  })
+})

--- a/scenarios/test_codegen/test/__mocks__/MockConfig.res
+++ b/scenarios/test_codegen/test/__mocks__/MockConfig.res
@@ -1,3 +1,5 @@
+open Belt
+
 let chain1 = ChainMap.Chain.makeUnsafe(~chainId=1)
 let chain137 = ChainMap.Chain.makeUnsafe(~chainId=137)
 let chain1337 = ChainMap.Chain.makeUnsafe(~chainId=1337)
@@ -6,28 +8,29 @@ let contracts = [
   {
     Config.name: "Gravatar",
     abi: Types.Gravatar.abi,
-    addresses: ["0x2B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"->Address.Evm.fromStringOrThrow],
+    addresses: [
+      "0x2B2f78c5BF6D9C12Ee1225D5F374aa91204580c3"->Address.Evm.fromStringOrThrow,
+    ],
     events: [
-      (Types.Gravatar.TestEvent.register() :> Internal.eventConfig),
       (Types.Gravatar.NewGravatar.register() :> Internal.eventConfig),
       (Types.Gravatar.UpdatedGravatar.register() :> Internal.eventConfig),
     ],
+    startBlock: None,
   },
   {
     name: "NftFactory",
     abi: Types.NftFactory.abi,
-    addresses: ["0xa2F6E6029638cCb484A2ccb6414499aD3e825CaC"->Address.Evm.fromStringOrThrow],
-    events: [(Types.NftFactory.SimpleNftCreated.register() :> Internal.eventConfig)],
-  },
-  {
-    name: "SimpleNft",
-    abi: Types.SimpleNft.abi,
-    addresses: [],
-    events: [(Types.SimpleNft.Transfer.register() :> Internal.eventConfig)],
+    addresses: [
+      "0xa2F6E6029638cCb484A2ccb6414499aD3e825CaC"->Address.Evm.fromStringOrThrow,
+    ],
+    events: [
+      (Types.NftFactory.SimpleNftCreated.register() :> Internal.eventConfig),
+    ],
+    startBlock: None,
   },
 ]
 
-let evmContracts = contracts->Js.Array2.map((contract): Internal.evmContractConfig => {
+let evmContracts = contracts->Array.map((contract): Internal.evmContractConfig => {
   name: contract.name,
   abi: contract.abi,
   events: contract.events->(
@@ -35,15 +38,15 @@ let evmContracts = contracts->Js.Array2.map((contract): Internal.evmContractConf
   ),
 })
 
-let mockChainConfig: Config.chainConfig = {
+let config: Config.chainConfig = {
   confirmedBlockThreshold: 200,
   startBlock: 1,
   endBlock: None,
-  chain: chain1337,
+  chain: ChainMap.Chain.makeUnsafe(~chainId=1337),
   contracts,
   sources: [
     RpcSource.make({
-      chain: chain1337,
+      chain: ChainMap.Chain.makeUnsafe(~chainId=1337),
       contracts: evmContracts,
       sourceFor: Sync,
       syncConfig: Config.getSyncConfig({
@@ -57,8 +60,8 @@ let mockChainConfig: Config.chainConfig = {
       }),
       url: "http://127.0.0.1:8545",
       eventRouter: evmContracts
-      ->Belt.Array.flatMap(contract => contract.events)
-      ->EventRouter.fromEvmEventModsOrThrow(~chain=chain1337),
+      ->Array.flatMap(contract => contract.events)
+      ->EventRouter.fromEvmEventModsOrThrow(~chain=ChainMap.Chain.makeUnsafe(~chainId=1337)),
     }),
   ],
 }

--- a/scenarios/test_codegen/test/lib_tests/FetchState_test.res
+++ b/scenarios/test_codegen/test/lib_tests/FetchState_test.res
@@ -71,6 +71,7 @@ let makeInitial = (~startBlock=0, ~blockLag=?) => {
   FetchState.make(
     ~eventConfigs=[baseEventConfig, baseEventConfig2],
     ~staticContracts=Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
+    ~staticContractsWithStartBlocks=Js.Dict.fromArray([("Gravatar", None)]),
     ~dynamicContracts=[],
     ~startBlock,
     ~endBlock=None,
@@ -150,6 +151,7 @@ describe("FetchState.make", () => {
         FetchState.make(
           ~eventConfigs=[baseEventConfig],
           ~staticContracts=Js.Dict.empty(),
+          ~staticContractsWithStartBlocks=Js.Dict.empty(),
           ~dynamicContracts=[],
           ~startBlock=0,
           ~endBlock=None,
@@ -171,6 +173,7 @@ describe("FetchState.make", () => {
       let fetchState = FetchState.make(
         ~eventConfigs=[baseEventConfig],
         ~staticContracts=Js.Dict.fromArray([("Gravatar", [mockAddress1])]),
+        ~staticContractsWithStartBlocks=Js.Dict.fromArray([("Gravatar", None)]),
         ~dynamicContracts=[dc],
         ~startBlock=0,
         ~endBlock=None,
@@ -227,6 +230,7 @@ describe("FetchState.make", () => {
           baseEventConfig,
         ],
         ~staticContracts=Js.Dict.fromArray([("ContractA", [mockAddress1])]),
+        ~staticContractsWithStartBlocks=Js.Dict.fromArray([("ContractA", None)]),
         ~dynamicContracts=[dc],
         ~startBlock=0,
         ~endBlock=None,
@@ -298,6 +302,7 @@ describe("FetchState.make", () => {
           baseEventConfig,
         ],
         ~staticContracts=Js.Dict.fromArray([("ContractA", [mockAddress1, mockAddress2])]),
+        ~staticContractsWithStartBlocks=Js.Dict.fromArray([("ContractA", None)]),
         ~dynamicContracts=[dc1, dc2],
         ~startBlock=0,
         ~endBlock=None,
@@ -539,6 +544,7 @@ describe("FetchState.registerDynamicContracts", () => {
           ) :> Internal.eventConfig),
         ],
         ~staticContracts=Js.Dict.fromArray([("Gravatar", [mockAddress0])]),
+        ~staticContractsWithStartBlocks=Js.Dict.fromArray([("Gravatar", None)]),
         ~dynamicContracts=[],
         ~startBlock=10,
         ~endBlock=None,
@@ -779,6 +785,10 @@ describe("FetchState.registerDynamicContracts", () => {
         ~staticContracts=Js.Dict.fromArray([
           ("NftFactory", [mockAddress0, mockAddress1]),
           ("Gravatar", [mockAddress2, mockAddress3]),
+        ]),
+        ~staticContractsWithStartBlocks=Js.Dict.fromArray([
+          ("NftFactory", None),
+          ("Gravatar", None),
         ]),
         ~dynamicContracts=[
           makeDynContractRegistration(
@@ -1592,6 +1602,7 @@ describe("FetchState.getNextQuery & integration", () => {
           wildcard,
         ],
         ~staticContracts=Js.Dict.fromArray([("ContractA", [mockAddress1])]),
+        ~staticContractsWithStartBlocks=Js.Dict.fromArray([("ContractA", None)]),
         ~dynamicContracts=[],
         ~startBlock=0,
         ~endBlock=None,
@@ -1732,6 +1743,7 @@ describe("FetchState.getNextQuery & integration", () => {
       FetchState.make(
         ~eventConfigs,
         ~staticContracts=Js.Dict.empty(),
+        ~staticContractsWithStartBlocks=Js.Dict.empty(),
         ~dynamicContracts=[],
         ~startBlock=0,
         ~endBlock=None,
@@ -1929,6 +1941,7 @@ describe("FetchState unit tests for specific cases", () => {
         wildcard,
       ],
       ~staticContracts=Js.Dict.fromArray([("ContractA", [mockAddress0])]),
+      ~staticContractsWithStartBlocks=Js.Dict.fromArray([("ContractA", None)]),
       ~dynamicContracts=[],
       ~startBlock=0,
       ~endBlock=None,
@@ -2070,6 +2083,7 @@ describe("FetchState unit tests for specific cases", () => {
         (Mock.evmEventConfig(~id="0", ~contractName="ContractA") :> Internal.eventConfig),
       ],
       ~staticContracts=Js.Dict.fromArray([("ContractA", [mockAddress1, mockAddress2])]),
+      ~staticContractsWithStartBlocks=Js.Dict.fromArray([("ContractA", None)]),
       ~dynamicContracts=[],
       ~startBlock=0,
       ~endBlock=None,
@@ -2198,6 +2212,10 @@ describe("FetchState unit tests for specific cases", () => {
       ~staticContracts=Js.Dict.fromArray([
         ("ContractA", [mockAddress1]),
         ("ContractB", [mockAddress2]),
+      ]),
+      ~staticContractsWithStartBlocks=Js.Dict.fromArray([
+        ("ContractA", None),
+        ("ContractB", None),
       ]),
       ~dynamicContracts=[],
       ~startBlock=0,
@@ -2412,6 +2430,7 @@ describe("FetchState unit tests for specific cases", () => {
       let fetchState = FetchState.make(
         ~eventConfigs=[baseEventConfig],
         ~staticContracts=Js.Dict.fromArray([("Gravatar", [mockAddress1])]),
+        ~staticContractsWithStartBlocks=Js.Dict.fromArray([("Gravatar", None)]),
         ~dynamicContracts=[],
         ~startBlock=0,
         ~endBlock=None,


### PR DESCRIPTION
This pull request introduces functionality to support per-contract start blocks in the indexing configuration. The changes enable specifying a custom `start_block` for each contract, allowing the indexer to begin data ingestion at different points for different contracts. The implementation includes schema updates, configuration handling, and additional tests to ensure correctness.

### Schema Updates:
* Added a `start_block` property to the EVM and Fuel schemas (`evm.schema.json` and `fuel.schema.json`). This property specifies the block number at which the indexer should start ingesting data for a specific contract. It supports `integer` or `null` values, with a minimum of 0. [[1]](diffhunk://#diff-bb927fa0e7568d164d6ffff0277409825c92e7aa5f3b080423837b6b538e8bceR579-R587) [[2]](diffhunk://#diff-036c285b8f2c6a7cc8b43b335e3ffc590ef8de77c7b4a68ecd0ce8e24ada08f1R220-R228)

### Configuration Handling:
* Updated the `FetchState` logic to compute the earliest start block across static and dynamic contracts. This ensures the indexer starts from the correct block for each contract (`FetchState.res`). [[1]](diffhunk://#diff-595a09115cb3870374f309467d7c760fd0d32e1b13e1c82a929c1dfbc1ceddd8R970-R991) [[2]](diffhunk://#diff-595a09115cb3870374f309467d7c760fd0d32e1b13e1c82a929c1dfbc1ceddd8R1071-R1081)
* Modified the `NetworkContract` structure to include an optional `start_block` field and updated related configuration parsing and serialization logic (`init_config.rs`, `system_config.rs`, and `human_config.rs`). [[1]](diffhunk://#diff-58fc707d023f097d00a623b4941724089b3244f6869dd4d938a8bf2fa08476d7R142) [[2]](diffhunk://#diff-75b92a5fdb4d3a3713f4101eded12625e7d7dcda746bc9806faa736d463ce563R1058) [[3]](diffhunk://#diff-cc55075d659585d2a669effdc0cb6fa5d80c155a791d672630db7be65486fc57R85-R90)

### Testing Enhancements:
* Added unit tests to validate the serialization, deserialization, and fallback behavior of the `start_block` field in various configurations. These tests ensure that contracts with and without `start_block` values are handled correctly (`human_config.rs` and `system_config.rs`). [[1]](diffhunk://#diff-cc55075d659585d2a669effdc0cb6fa5d80c155a791d672630db7be65486fc57R903-R981) [[2]](diffhunk://#diff-75b92a5fdb4d3a3713f4101eded12625e7d7dcda746bc9806faa736d463ce563R2144-R2197)

### Template Updates:
* Updated the Handlebars templates to include the `start_block` field in the generated configuration files (`codegen_templates.rs` and `ConfigYAML.res.hbs`). [[1]](diffhunk://#diff-397a12b9c61f31aabb93bb396c759d3ff609683b3d778485125ed810dd1953c0R878) [[2]](diffhunk://#diff-3247c379ab58ef4707ed63ccd56e1530adab70ea1771d646861d20920d3ab63bR23)